### PR TITLE
Remove version from composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ PSRs you support to avoid any confusion with users and contributors.
 Via Composer
 
 ``` bash
-$ php composer.phar require league/skeleton:~1.0
+$ php composer.phar require league/skeleton
 ```
 
 ## Usage


### PR DESCRIPTION
Composer detects the latest stable version (only 0.x should specify the version)
http://blog.doh.ms/2014/10/13/installing-composer-packages/
