### PR TITLE
Add Ocular as dev-dependency, fixes HHVM issues too apparently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ script:
   - phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php" : ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "4.*"
+        "phpunit/phpunit" : "4.*",
+        "scrutinizer/ocular": "~1.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I use this repo as a start for projects, and noticed Scrutinizer was not receiving code coverage results. After speaking to their support, they advised me to do this, and now everything's working properly again.