### PR TITLE
[Travis] Test lowest version dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,14 @@ php:
   - 5.6
   - hhvm
 
+matrix:
+  include:
+  - php: 5.3
+    env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source --dev
 
 script:
   - phpunit --coverage-text --coverage-clover=coverage.clover


### PR DESCRIPTION
I would like to propose that every tactician package should also test it's lowest dependencies.
The reason to test the lowest dependencies is to avoid BC breaks.