### PR TITLE
Don't ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
-composer.lock
 docs
 vendor


### PR DESCRIPTION
> Commit your **application's** composer.lock (along with composer.json) into version control.

https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file

> For your **library** you may commit the composer.lock file if you want to. This can help your team to always test against the same dependency versions. However, this lock file will not have any effect on other projects that depend on it. It only has an effect on the main project.

https://getcomposer.org/doc/02-libraries.md#lock-file