### PR TITLE
Added end_of_line & some more info about this file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,5 @@
-# editorconfig.org
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://editorconfig.org
 
 root = true
 
@@ -6,6 +7,7 @@ root = true
 charset = utf-8
 indent_size = 4
 indent_style = space
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
> It is acceptable and often preferred to leave certain EditorConfig properties unspecified. For example [...] if a property is not standardized in your project (end_of_line for example), it may be best to leave it blank.

http://editorconfig.org/#file-format-details

I added ``end_of_line`` nonetheless, as I think there is an agreement to always use ``lf``.

I did not include the ``*.yml`` section from https://github.com/thephpleague/skeleton/pull/24#issuecomment-101760015
As I was not sure if there is  a consent about  the indent size in yml files.

````
[*.yml]
indent_style = space
indent_size = 2
````
The ``indent_style`` would be  redundant anyway...