### PR TITLE
Do not call ocular in PHP 7.0 and HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover; fi


### PR DESCRIPTION
We cannot be dead certain that those support code coverage, so they would break the Scrutinizer build the following message "Scrutinizer was notified that the tests failed." even though all Travis builds succeeded.

I had this problem and contacted the Scrutinizer support, which answered me:
> if you check the individual build jobs, there should be one where the upload command outputs something like "Notifying that no code coverage is available". This is typically happening for the HHVM build, or a PHP 7 build which both do not support running code coverage.
> To fix this, make sure that you do not run the upload command for these versions. There is an example of how to do this here:
https://github.com/FriendsOfSymfony/FOSRestBundle/blob/28853daaf36e872d7d1b01d6ffaa5dcfceabda85/.travis.yml#L43-L44

At the moment HHVM seems to work, excluding it nonetheless.
Also now it correlates with three runs configured in https://github.com/thephpleague/skeleton/blob/13bd2abaeb4bbfac119533e4373a6975222922f8/.scrutinizer.yml#L23