### PR TITLE
Use Packagist Release badge instead of GH release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # :package_name
 
-[![Latest Version](https://img.shields.io/github/release/thephpleague/:package_name.svg?style=flat-square)](https://github.com/thephpleague/:package_name/releases)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/league/:package_name.svg?style=flat-square)](https://packagist.org/packages/league/:package_name)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/thephpleague/:package_name/master.svg?style=flat-square)](https://travis-ci.org/thephpleague/:package_name)
 [![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/thephpleague/:package_name.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/:package_name/code-structure)


### PR DESCRIPTION
Because most repos don't do releases, they just tag their revisons. Which suffices for Composer/Packagist - but the current badge would simply state "Release: None"...

Alternatively the GH Tag badge could be used instead.