### PR TITLE
Add Composer scripts "check-codestyle" & "fix-codestyle"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/:vendor
 
 ## Pull Requests
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - Check the code style with ``$ composer check-codestyle`` and fix it with ``$ composer fix-codestyle``.
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - Check the code style with ``$ composer check-style`` and fix it with ``$ composer fix-style``.
 
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We accept contributions via Pull Requests on [Github](https://github.com/:vendor
 
 ## Pull Requests
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - Check the code style with ``$ composer check-codestyle`` and fix it with ``$ composer fix-codestyle``.
 
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
     },
     "scripts": {
         "test": "phpunit",
-        "check-codestyle": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
-        "fix-codestyle": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
+        "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
+        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpunit/phpunit" : "~4.0||~5.0",
         "scrutinizer/ocular": "~1.1",
-        "squizlabs/php_codesniffer": "~2.3"
+      "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "phpunit/phpunit" : "~4.0||~5.0",
         "scrutinizer/ocular": "~1.1",
-      "squizlabs/php_codesniffer": "^2.3"
+        "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     },
     "scripts": {
         "test": "phpunit",
-        "format": "phpcbf --standard=psr2 src/"
+        "check-codestyle": "phpcs -p --standard=PSR2 src tests",
+        "fix-codestyle": "phpcbf  -p --standard=PSR2 src tests"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
     },
     "scripts": {
         "test": "phpunit",
-        "check-codestyle": "phpcs -p --standard=PSR2 src tests",
-        "fix-codestyle": "phpcbf  -p --standard=PSR2 src tests"
+        "check-codestyle": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
+        "fix-codestyle": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This adds the PHP CodeSniffer as development dependency and adds two Composer scripts "check-codestyle" & "fix-codestyle" for checking and auto-fixing the code style.

Partly relevant: https://github.com/thephpleague/skeleton/issues/21#issuecomment-103568309

UPDATE: Fixed through https://github.com/thephpleague/skeleton/pull/41#issuecomment-104071697 by  @gsherwood 
~~There is one "imperfection", though...~~
~~If there are CS errors and/or warnings found by phpcs, Composer will report the following error:~~

````
Script phpcs -p --standard=PSR2 src tests handling the check-codesyle event returned with an error



  [RuntimeException]
  Error Output:



check-codesyle [--dev] [--no-dev] [args1] ... [argsN]
````

~~This is due to the exit code that phpcs returns if errors and/or warnings are found.~~

~~This can be suppressed through:~~

```` bash
phpcs --config-set ignore_errors_on_exit 1
phpcs --config-set ignore_warnings_on_exit 1
````

~~https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#ignoring-errors-when-generating-the-exit-code~~

~~Unfortunately there is no CLI switch for them when running the check.~~