### PR TITLE
composer.lock must be commited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
-composer.lock
 docs
 vendor


### PR DESCRIPTION
> anyone who sets up the project will download the exact same version of the dependencies

from [GetComposer](https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file)