### PR TITLE
Remove composer.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
-composer.lock
 docs
 vendor


### PR DESCRIPTION
I have removed the entry for the `composer.lock` file as it is considered good practice to commit this with the `composer.json` file as per [here](https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file).

Nigel