### PR TITLE
Revert `composer test` in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": "phpunit"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
First, composer will push its bin to the top of the $PATH when running composer scripts, so this isn't strictly necessary. Secondly, using `/` will fail on Windows. This reverts one of the changes previously made in 54f6cbc6064e56e92ab59db46f99f9ff815d055d.

Sorry guys!