### PR TITLE
update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,2 @@
 # Path-based git attributes
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
-
-# Ignore all test and documentation with "export-ignore".
-/.gitattributes     export-ignore
-/.gitignore         export-ignore
-/.travis.yml        export-ignore
-/phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
-/tests              export-ignore


### PR DESCRIPTION
the `export-ignore` prevents the zip file from containing all of these files. as this is a package to scaffold new packages, I think these files should be included in the zip. that way we have stubs to start creating our new package.