### PR TITLE
Added disclaimer to code of conduct application

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -15,7 +15,7 @@ Examples of unacceptable behavior by participants include:
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community in a direct capacity. Personal views, beliefs and values of individuals do not necessarily reflect those of The League of Extraordinary Packages or other maintainers and contributors.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -15,7 +15,7 @@ Examples of unacceptable behavior by participants include:
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community in a direct capacity. Personal views, beliefs and values of individuals do not necessarily reflect those of The League of Extraordinary Packages or other maintainers and contributors.
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community in a direct capacity. Personal views, beliefs and values of individuals do not necessarily reflect those of the organisation or affiliated individuals and organisations.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 


### PR DESCRIPTION
This PR narrows the scope of when and where this code of conduct can apply.

It is absolutely right that during a conference talk or tuition or representation of The League or a League project that proper conduct be applied. Likewise on any League social media account or project specific social media account.

However it should not limit personal freedom of speech outside of this capacity. For example stating publicly (such as in a personal Twitter profile bio) that one is the maintainer of `league/packageX` should not result in this conduct being used against them because one got into an argument or aired a view that others might take offence to.

Thoughts? @thephpleague/admins 