### PR TITLE
composer.lock shouldn't be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
-composer.lock
 docs
 vendor


### PR DESCRIPTION
According to the composer's documentation, the composer.lock should be versioned.
cf: https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file