### PR TITLE
Disallow PHP 7 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ php:
 sudo: false
 
 matrix:
-  allow_failures:
-    - php: 7.0
   include:
     - php: 5.4
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'


### PR DESCRIPTION
PHP 7 is now stable and Travis is using these stable builds for testing