### PR TITLE
Add .styleci.yml

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,1 @@
+preset: psr2


### PR DESCRIPTION
[StyleCI](https://styleci.io/) can automatically check source code against PSR2.

Some project may want to use more-strict code styles, which is fine, but since PSR2 is a League requirement I figured this would be a good default config.