### PR TITLE
Bump minimum PHP version to 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php" : ">=5.3.0"
+        "php" : ">=5.4.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*",


### PR DESCRIPTION
The minimum version in the Travis config is 5.4.  If packages aren't going to be tested on 5.3 then I think the minimum version should be bumped here.

I'd also be open to making this 5.5 (now, or sometime in the future) since 5.4 is technically unsupported.