### PR TITLE
Bump to PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php" : ">=5.4.0"
+        "php" : "~5.5|~7.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*",


### PR DESCRIPTION
Followup to #65

It makes sense to create new packages only for live (safe) versions.