### PR TITLE
Removed redundant Test namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            ":vendor\\:package_name\\Test\\": "tests"
+            ":vendor\\:package_name\\": "tests"
         }
     },
     "scripts": {

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace League\Skeleton\Test;
+namespace League\Skeleton;
 
 class ExampleTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Additional `Test` sub-namespace increases complexity and benefits no one.

For example, without this sub-namespace one can simply refer to classes by name. With it still present, one must add `use` statement for every class.

Therefore, if we don't use additional namespacing, we could much better see that there is no mistake and every tested class belongs to the very same namespace. Else we could expect any kind on confusion especially with similarly-named classes in different namespaces.

See #71

