### PR TITLE
composer scripts: prefer package dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
         }
     },
     "scripts": {
-        "test": "phpunit",
-        "format": "phpcbf --standard=psr2 src/"
+        "test": "vendor/bin/phpunit",
+        "format": "vendor/bin/phpcbf --standard=psr2 src/"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Scripts can be missing in the path, oppose to composer dependencies that are always installed. And in correct version.

This **might** work:

```bash
phpunit
phpcbf --standard=psr2 src/
```

This **WILL** work:

```bash
vendor/bin/phpunit
vendor/bin/phpcbf --standard=psr2 src/
```

Follow up to #80