### PR TITLE
Enhancement: Keep packages sorted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,8 @@
         "branch-alias": {
             "dev-master": "1.0-dev"
         }
+    },
+    "config": {
+        "sort-packages": true
     }
 }


### PR DESCRIPTION
This PR

* [x] adds a configuration to `composer.json` which keeps packages sorted

💁 Ain't nobody got time to type 

```
$ composer require --sort-packages foo/bar
```

all the time!

h/t @hannesvdvreken