### PR TITLE
Update php version required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php" : "~5.5|~7.0"
+        "php" : "~5.6|~7.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "~4.0||~5.0",


### PR DESCRIPTION
In order to require only [supported](http://php.net/supported-versions.php) php version, update minimum php version required from [5.5](http://php.net/eol.php) to 5.6.