### PR TITLE
Add composer script "format-win" for Windows users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     },
     "scripts": {
         "test": "phpunit",
-        "format": "phpcbf --standard=psr2 src/"
+        "format": "phpcbf --standard=psr2 src/",
+        "format-win": "phpcbf --standard=psr2 --no-patch src/"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
On Windows sytems, `composer format` fails because the commands `diff` and `patch` do not exist.

Script "format-win" allows `phpcbf` to work properly on Windows by adding the switch `--no-patch` as suggested here: https://github.com/squizlabs/PHP_CodeSniffer/issues/458 .

Fixes #84.
