### PR TITLE
travis: bump min version to PHP 5.6, add PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 # This triggers builds to run on the new TravisCI infrastructure.
@@ -17,7 +17,7 @@ cache:
 
 matrix:
   include:
-    - php: 5.5
+    - php: 5.6
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:


### PR DESCRIPTION
Min version is PHP 5.6, see composer: https://github.com/thephpleague/skeleton/blob/ad403d7a63d7f2989657960d2e9e84e90fa3be9a/composer.json#L20
Also PHP 7.1 is available on Travis