### PR TITLE
add the xml.dist extesion to the prefil script

### DIFF
--- a/prefill.php
+++ b/prefill.php
@@ -13,7 +13,7 @@ $fields = [
     'package_vendor' =>         ['Package vendor',        '<vendor> in https://github.com/vendor/package',   '{author_github_username}'],
     'package_name' =>           ['Package name',          '<package> in https://github.com/vendor/package',  ''],
     'package_description' =>    ['Package very short description',   '',                                     ''],
-    
+
     'psr4_namespace' =>         ['PSR-4 namespace',       'usually, Vendor\\Package',                        '{package_vendor}\\{package_name}'],
 ];
 
@@ -61,9 +61,9 @@ do {
     if ($modify == 'q') {
         exit;
     }
-    
+
     $values = [];
-    
+
     echo "----------------------------------------------------------------------\n";
     echo "Please, provide the following information:\n";
     echo "----------------------------------------------------------------------\n";
@@ -81,7 +81,7 @@ do {
         }
     }
     echo "\n";
-    
+
     echo "----------------------------------------------------------------------\n";
     echo "Please, check that everything is correct:\n";
     echo "----------------------------------------------------------------------\n";
@@ -94,6 +94,7 @@ echo "\n";
 
 $files = array_merge(
     glob(__DIR__ . '/*.md'),
+    glob(__DIR__ . '/*.xml.dist'),
     glob(__DIR__ . '/composer.json'),
     glob(__DIR__ . '/src/*.php')
 );


### PR DESCRIPTION
## Description

It includes the *.xml.dist file extension to the prefil.php, so it replace the :vendor in the phpunit.xml.dist file.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
