### PR TITLE
Fix #87 | "docs" entry in .gitignore?

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@
 /phpunit.xml.dist   export-ignore
 /.scrutinizer.yml   export-ignore
 /tests              export-ignore
+/docs               export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
 composer.lock
-docs
 vendor


### PR DESCRIPTION
Remove docs directory out of .gitignore and locate it in .gitattributes