### PR TITLE
Removed trailing comma from call to array_merge.

### DIFF
--- a/prefill.php
+++ b/prefill.php
@@ -17,7 +17,9 @@ $fields = [
     'psr4_namespace' =>         ['PSR-4 namespace',       'usually, Vendor\\Package',                        '{package_vendor}\\{package_name}'],
 ];
 
-$values = [];
+$values = [
+
+];
 
 $replacements = [
     ':vendor\\\\:package_name\\\\' => function () use(&$values) { return str_replace('\\', '\\\\', $values['psr4_namespace']) . '\\\\'; },
@@ -97,7 +99,7 @@ $files = array_merge(
     glob(__DIR__ . '/*.xml.dist'),
     glob(__DIR__ . '/composer.json'),
     glob(__DIR__ . '/src/*.php'),
-    glob(__DIR__ . '/tests/*.php'),
+    glob(__DIR__ . '/tests/*.php')
 );
 foreach ($files as $f) {
     $contents = file_get_contents($f);

--- a/prefill.php
+++ b/prefill.php
@@ -17,9 +17,7 @@ $fields = [
     'psr4_namespace' =>         ['PSR-4 namespace',       'usually, Vendor\\Package',                        '{package_vendor}\\{package_name}'],
 ];
 
-$values = [
-
-];
+$values = [];
 
 $replacements = [
     ':vendor\\\\:package_name\\\\' => function () use(&$values) { return str_replace('\\', '\\\\', $values['psr4_namespace']) . '\\\\'; },


### PR DESCRIPTION
Removed trailing comma from call to array_merge.

## Description

Removed trailing comma from call to array_merge. Small bug that was easily fixed.

## Motivation and context

this resolves the error that was thrown as a result of having a trailing comma in a function call.

## How has this been tested?
tested by running prefill.php from the command line. 

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [ x ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ x ] My pull request addresses exactly one patch/feature.
- [ ] I have created a branch for this patch/feature.
- [ ] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

I figure this doesn't need a branch or tests, just removed a comma that broke the script.
