### PR TITLE
Adds git hooks to skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ tests/
 vendor/
 ```
 
+## Git hooks
+
+This project has [ebastianfeldmann/captainhook](https://github.com/sebastianfeldmann/captainhook) installed. This will:
+
+ - Run `composer check-style` on pre-commit to check that the PSR2 standard is kept
+ - Run `composer test` on pre-push to run tests to ensure any broken tests are not pushed
 
 ## Install
 

--- a/captainhook.json
+++ b/captainhook.json
@@ -1,0 +1,22 @@
+{
+    "commit-msg": {
+        "enabled": false,
+        "actions": []
+    },
+    "pre-commit": {
+        "enabled": true,
+        "actions": [
+            {
+                "action": "composer check-style"
+            }
+        ]
+    },
+    "pre-push": {
+        "enabled": true,
+        "actions": [
+            {
+                "action": "composer test"
+            }
+        ]
+    }
+}

--- a/captainhook.json
+++ b/captainhook.json
@@ -7,7 +7,7 @@
         "enabled": true,
         "actions": [
             {
-                "action": "composer check-style"
+                "action": "./vendor/bin/phpcs --standard=psr2 src tests"
             }
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "require-dev": {
         "phpunit/phpunit" : "~4.0||~5.0||~6.0",
-        "squizlabs/php_codesniffer": "^2.3"
+        "squizlabs/php_codesniffer": "^2.3",
+        "sebastianfeldmann/captainhook": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -36,7 +37,8 @@
     "scripts": {
         "test": "phpunit",
         "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
-        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
+        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
+        "remove-git-hooks": "rm ./.git/hooks/*"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows `composer check-style` to be ran on `pre-commit` and `composer test` on `pre-push`.

## Motivation and context

For me, it is about bringing all engineers inline. At the end of the day we are only human and automation on things like this allows to concentrate on the problem to solve and reduce potential stress.

## How has this been tested?

Ran `./vendor/bin/captinhook install` and made breaking changes on code and tests to check the errors stop committing and pushing to remote.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
