### PR TITLE
Fix tests on PHP 5.6 & HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 php:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php" : "~5.6|~7.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "~4.0||~5.0||~6.0",
+        "phpunit/phpunit" : ">=5.4.3",
         "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload": {

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -2,7 +2,7 @@
 
 namespace League\Skeleton;
 
-class ExampleTest extends \PHPUnit_Framework_TestCase
+class ExampleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test that true does in fact equal true


### PR DESCRIPTION
This fixes thephpleague/skeleton/issues/114

The minimum requirement for PHPUnit when run with `--prefer-lowest` is [5.4.3](https://github.com/sebastianbergmann/phpunit/blob/5.4/ChangeLog-5.4.md#543---2016-06-09)
(more precisely it would be [4.8.35](https://github.com/sebastianbergmann/phpunit/blob/4.8/ChangeLog-4.8.md#4835---2017-02-06), but since the default PHP requirement is PHP 5.6 there is no point in targeting 4.8)

Also fixing tests on HHVM which require now `dist: trusty` to run

[All tests pass](https://travis-ci.org/ozh/skeltest) with this.