### PR TITLE
Fix: Camelize the default value of `psr4_namespace`

### DIFF
--- a/prefill.php
+++ b/prefill.php
@@ -14,7 +14,7 @@ $fields = [
     'package_name' =>           ['Package name',          '<package> in https://github.com/vendor/package',  ''],
     'package_description' =>    ['Package very short description',   '',                                     ''],
 
-    'psr4_namespace' =>         ['PSR-4 namespace',       'usually, Vendor\\Package',                        '{package_vendor}\\{package_name}'],
+    'psr4_namespace' =>         ['PSR-4 namespace',       'usually, Vendor\\Package',                        '{psr_vendor}\\{psr_package}'],
 ];
 
 $values = [];
@@ -56,6 +56,11 @@ function interpolate($text, $values)
     return $text;
 }
 
+function camelize($text)
+{
+    return strtr(ucwords(strtr($text, ['-' => ' ', '_' => ' ', '.' => '_ '])), [' ' => '']);
+}
+
 $modify = 'n';
 do {
     if ($modify == 'q') {
@@ -78,6 +83,12 @@ do {
         $values[$f] = read_from_console($prompt);
         if (empty($values[$f])) {
             $values[$f] = $default;
+        }
+        if ($f == 'package_vendor') {
+            $values['psr_vendor'] = camelize($values[$f]);
+        }
+        if ($f == 'package_name') {
+            $values['psr_package'] = camelize($values[$f]);
         }
     }
     echo "\n";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The users don't need to input the namespace in most cases if Vendor\PackageName is used as the default value.

Although the PSR did not make a recommendation, it was a de facto standard.
PSR survey result on `class_names`:
https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md#a3-survey-results

## Motivation and context

If some people input vendor `foo` and package name `hello-world`, then the default namespace was `foo\hello-world`, indeed a invalid namespace, he had to input the namespace `Foo\HelloWorld` again.

## How has this been tested?

Tested by running prefill.php from the command line like this:
```
...
Package vendor (<vendor> in https://github.com/vendor/package) [foo]: 
Package name (<package> in https://github.com/vendor/package): hello-world
Package very short description: 
PSR-4 namespace (usually, Vendor\Package) [Foo\HelloWorld]: 
...
```

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
