### PR TITLE
travis: drop old explicit sudo:false, now by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 language: php
 
 php:
@@ -7,10 +6,6 @@ php:
   - 7.1
   - 7.2
   - hhvm
-
-# This triggers builds to run on the new TravisCI infrastructure.
-# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
 
 ## Cache composer
 cache:


### PR DESCRIPTION
This option is set by default since 2016.
It doesn't make sense to provide it for 2018 packages

See: https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments




![image](https://user-images.githubusercontent.com/924196/34632503-136e22c8-f276-11e7-9ba3-ddb29313e91c.png)
  