### PR TITLE
commit `composer.lock` to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 build
-composer.lock
 vendor


### PR DESCRIPTION
having the lock file in the package repo is good because it means all collaborators will be testing against identical versions.

It will have no effect on the top-level application, which is only concerned with package `composer.json` files.

https://getcomposer.org/doc/02-libraries.md#lock-file