### PR TITLE
Use new PHP analysis engine

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,11 @@
+build:
+    nodes:
+        analysis:
+            project_setup:
+                override: true
+            tests:
+                override: [php-scrutinizer-run]
+
 filter:
     excluded_paths: [tests/*]
 


### PR DESCRIPTION
## Description

Added Scrutinizer configuration that enabled new PHP analysis engine

## Motivation and context

Was using skeleton configuration for my own repository, noticed warnings in Scrutinizer page that PHP analysis engines can be upgraded.

## How has this been tested?

Tested in my own repository. Warnings in Scrutinizer are gone.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

