### PR TITLE
Added a phpcs.xml.dist file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.travis.yml        export-ignore
+/phpcs.xml.dist     export-ignore
 /phpunit.xml.dist   export-ignore
 /.scrutinizer.yml   export-ignore
 /tests              export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 composer.lock
 vendor
+phpcs.xml
+phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit" : ">=5.4.3",
-        "squizlabs/php_codesniffer": "^2.3"
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -35,8 +35,8 @@
     },
     "scripts": {
         "test": "phpunit",
-        "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests",
-        "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src tests"
+        "check-style": "phpcs src tests",
+        "fix-style": "phpcbf src tests"
     },
     "extra": {
         "branch-alias": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name=":package_name">
+    <description>The coding standard of :package_name package</description>
+    <arg value="p" />
+
+    <config name="ignore_warnings_on_exit" value="1" />
+    <config name="ignore_errors_on_exit" value="1" />
+
+    <arg name="colors" />
+    <arg value="s" />
+
+    <!-- Use the PSR2 Standard-->
+    <rule ref="PSR2" />
+</ruleset>


### PR DESCRIPTION
## Description

I have added a phpcs.xml.dist file for codesniffer.

This dist file works in the same logic as phpunit.xml.dist. Developers can add their own custom one.

I don't know exactly the version that codesniffer package added this feature. Going through the releases I think it is on 2.5.0. So it might be better if we wait for this #129 to be merged first.

## Motivation and context

Adding an XML with rules is more friendly rather than running through the command line the rules that you need.

## How has this been tested?

I have run composer update and executed the commands of composer.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
