### PR TITLE
Drop support for PHP5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -20,7 +19,7 @@ cache:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.0
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         }
     ],
     "require": {
-        "php" : "~5.6|~7.0"
+        "php" : "~7.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : ">=5.4.3",
+        "phpunit/phpunit" : ">=7.0",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,7 +21,7 @@
     </filter>
     <logging>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/src/SkeletonClass.php
+++ b/src/SkeletonClass.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace League\Skeleton;
 
 class SkeletonClass
@@ -19,7 +21,7 @@ class SkeletonClass
      *
      * @return string Returns the phrase passed in
      */
-    public function echoPhrase($phrase)
+    public function echoPhrase(string $phrase): string
     {
         return $phrase;
     }

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace League\Skeleton;
 
 class ExampleTest extends \PHPUnit\Framework\TestCase


### PR DESCRIPTION
From today PHP 5 is no longer supported.

- Drop support for PHP5
- Suggest latest PHPUnit version
- Add declare strict types
- Add typehints.