### PR TITLE
Set default package_name to current directory

### DIFF
--- a/prefill.php
+++ b/prefill.php
@@ -11,7 +11,7 @@ $fields = [
     'author_website' =>         ['Your website',          '',                                                'https://github.com/{author_github_username}'],
 
     'package_vendor' =>         ['Package vendor',        '<vendor> in https://github.com/vendor/package',   '{author_github_username}'],
-    'package_name' =>           ['Package name',          '<package> in https://github.com/vendor/package',  ''],
+    'package_name' =>           ['Package name',          '<package> in https://github.com/vendor/package',  basename(__DIR__)],
     'package_description' =>    ['Package very short description',   '',                                     ''],
 
     'psr4_namespace' =>         ['PSR-4 namespace',       'usually, Vendor\\Package',                        '{package_vendor}\\{package_name}'],


### PR DESCRIPTION
Sets the default `package_name` pf the `prefill.php` script to the current folder (before it was empty).

## Description

Previously, when the `prefill.php` script was run, the package name was empty by default.

A more sensible default is the name of the current directory: `basename(__DIR__)`.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes. **Does not apply.**
- [ ] If my change requires a change to the documentation, I have updated it accordingly. **Does not apply.**
