### PR TITLE
Add cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+**Initialization notes**
+
+Clone this repository to create your new PHP package skeleton:
+
+```bash
+git clone --depth=1 https://github.com/thephpleague/skeleton.git my-extraordinary-package
+cd my-extraordinary-package
+rm -rf .git
+```
+
+Replace `:author_name`, `:author_username`, `:author_website`, `:author_email`, `:vendor`, `:package_name` and `:package_description` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](CONTRIBUTING.md), [LICENSE.md](LICENSE.md) and [composer.json](composer.json) files. You can run `php prefill.php` in the command line to make all replacements at once.
+
+Delete these initialization notes from `README.md` and the file `prefill.php` when you are done.
+
+---
+
 # :package_name
 
 [![Latest Version on Packagist][ico-version]][link-packagist]
@@ -7,8 +23,6 @@
 [![Quality Score][ico-code-quality]][link-code-quality]
 [![Total Downloads][ico-downloads]][link-downloads]
 
-**Note:** Replace ```:author_name``` ```:author_username``` ```:author_website``` ```:author_email``` ```:vendor``` ```:package_name``` ```:package_description``` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](CONTRIBUTING.md), [LICENSE.md](LICENSE.md) and [composer.json](composer.json) files, then delete this line. You can run `$ php prefill.php` in the command line to make all replacements at once. Delete the file prefill.php as well.
-
 This is where your description should go. Try and limit it to a paragraph or two, and maybe throw in a mention of what
 PSRs you support to avoid any confusion with users and contributors.
 
@@ -17,7 +31,7 @@ PSRs you support to avoid any confusion with users and contributors.
 If any of the following are applicable to your project, then the directory structure should follow industry best practices by being named the following.
 
 ```
-bin/        
+bin/
 build/
 docs/
 config/
@@ -25,7 +39,6 @@ src/
 tests/
 vendor/
 ```
-
 
 ## Install
 


### PR DESCRIPTION
Add cloning instructions to `README.md` and place them on the top.

## Motivation and context

Provide detailed instructions on how to clone the skeleton repo and delete the `.git` directory.

Place these instructions on the top of README.md, to have them separated from the skeleton project template. Before, they were located between the badges and the description.
