### PR TITLE
Bump PHP version to 8.5

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,31 +1,30 @@
 build:
-    nodes:
-        analysis:
-            project_setup:
-                override: true
-            tests:
-                override: [php-scrutinizer-run]
+  # You can explicitly set the PHP version you want, e.g. 8.2
+  nodes:
+    analysis:
+      environment:
+        php:
+          version: 8.5
+      project_setup:
+        override: true
+      tests:
+        override:
+          - php-scrutinizer-run
 
 filter:
-    excluded_paths: [tests/*]
+  excluded_paths:
+    - tests/*
+    - vendor/*
 
 checks:
-    php:
-        remove_extra_empty_lines: true
-        remove_php_closing_tag: true
-        remove_trailing_whitespace: true
-        fix_use_statements:
-            remove_unused: true
-            preserve_multiple: false
-            preserve_blanklines: true
-            order_alphabetically: true
-        fix_php_opening_tag: true
-        fix_linefeed: true
-        fix_line_ending: true
-        fix_identation_4spaces: true
-        fix_doc_comments: true
+  php:
+    enabled: true
+
+build_failure_conditions:
+  - 'issues.severity(>= MAJOR).new.exists'
+  - 'project.metric("scrutinizer.quality", < 8)'
 
 tools:
-    external_code_coverage:
-        timeout: 600
-        runs: 3
+  external_code_coverage:
+    timeout: 600
+    runs: 3

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
         }
     ],
     "require": {
-        "php" : "~7.2"
+        "php" : "~8.5"
     },
     "require-dev": {
-        "phpunit/phpunit" : ">=8.0",
-        "squizlabs/php_codesniffer": "^3.0"
+        "phpunit/phpunit" : ">=13.0",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION

## Description

Bump the PHP version and the used packages to 8.5 and the compatible versions

## Motivation and context

Using PHP 7.2 is problematic since the support for it has already ended. More about it [here](https://www.php.net/eol.php)

**Note on `scrutinizer.yml`**: Removed unsupported keys like `fix_identation_4spaces` and other `fix_*` settings that aren’t supported anymore. Scrutinizer no longer configures coding-style fixes directly in the `checks.php` block. More about it [here](https://scrutinizer-ci.com/docs/configuration)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
